### PR TITLE
Typo in GET function

### DIFF
--- a/ti.xhr.js
+++ b/ti.xhr.js
@@ -15,7 +15,7 @@ XHR.prototype.GET = function(e) {
     var onError = e.onError || function() {};
     
     if (e.extraParams) {
-        var extraParams = addDefaultsToOptions(e.xtraParams);
+        var extraParams = addDefaultsToOptions(e.extraParams);
     } else {
         var extraParams = storedExtraParams;
     }


### PR DESCRIPTION
The section of code which determines which extraParams to use in a GET request, the parameter to the addDefaultsToOptions is incorrect.